### PR TITLE
Persist daily game result

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import ControlButton from "./_components/button/control-button";
 import Grid from "./_components/game/grid";
 import GameLostModal from "./_components/modal/game-lost-modal";
@@ -33,6 +33,18 @@ export default function Home() {
   const [showGameWonModal, setShowGameWonModal] = useState(false);
   const [showGameLostModal, setShowGameLostModal] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+
+  useEffect(() => {
+    if (isWon) {
+      setShowGameWonModal(true);
+    }
+  }, [isWon]);
+
+  useEffect(() => {
+    if (isLost) {
+      setShowGameLostModal(true);
+    }
+  }, [isLost]);
 
   const {
     guessAnimationState,


### PR DESCRIPTION
## Summary
- store win/loss outcomes in local storage with a daily reset keyed to Astana time (UTC+5)
- restore cleared categories, guess history, and remaining mistakes when a stored result exists and auto-open the corresponding modal

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd069ecb9c83338057be0d74383be3