### PR TITLE
Load daily puzzle data from CSV

### DIFF
--- a/app/_examples.ts
+++ b/app/_examples.ts
@@ -1,165 +1,68 @@
-import { Category } from "./_types";
-import { getAstanaDayOfYear } from "./_time";
+import { DailyPuzzle, normalizeText } from "./_puzzle-data";
 
-const CSV_URL =
-  "https://docs.google.com/spreadsheets/d/e/2PACX-1vQbFVnlcBrpSGHk8PSuGophCOSUl5N-U9HBI6G352dZPgGlZGK1AdA0xduUeqPSfSW-8Om7C8GV8rcb/pub?gid=1108981138&single=true&output=csv";
-
-type PuzzleRow = {
-  dayOfYear: number;
-  categories: Category[];
+type FetchDailyPuzzleOptions = {
+  forceRefresh?: boolean;
 };
 
-const normalizeText = (value: string): string =>
-  value.replace(/\s+/g, " ").trim().toLocaleUpperCase("kk-KZ");
+const normalizePuzzle = (puzzle: DailyPuzzle): DailyPuzzle => ({
+  ...puzzle,
+  categories: puzzle.categories.map((category) => ({
+    ...category,
+    category: normalizeText(category.category),
+    items: category.items.map((item) => normalizeText(item)),
+  })),
+});
 
-const parseCategoryColumn = (
-  value: string | undefined,
-  level: 1 | 2 | 3 | 4
-): Category | null => {
-  if (!value) {
-    return null;
-  }
+let cachedPuzzle: DailyPuzzle | null = null;
+let pendingPuzzlePromise: Promise<DailyPuzzle> | null = null;
 
-  const trimmed = value.trim();
-
-  if (!trimmed) {
-    return null;
-  }
-
-  const openParenIndex = trimmed.indexOf("(");
-  const closeParenIndex = trimmed.lastIndexOf(")");
-
-  if (openParenIndex === -1 || closeParenIndex === -1 || closeParenIndex <= openParenIndex) {
-    return null;
-  }
-
-  const categoryName = trimmed.slice(0, openParenIndex).trim();
-  const itemsSection = trimmed.slice(openParenIndex + 1, closeParenIndex).trim();
-
-  if (!categoryName || !itemsSection) {
-    return null;
-  }
-
-  const rawItems = itemsSection
-    .split(",")
-    .map((item) => item.trim())
-    .filter((item) => item.length > 0);
-
-  if (rawItems.length < 4) {
-    return null;
-  }
-
-  const normalizedCategory = normalizeText(categoryName);
-  const items = rawItems.slice(0, 4).map((item) => normalizeText(item));
-
-  return {
-    category: normalizedCategory,
-    items,
-    level,
-  };
-};
-
-const parseCsvLine = (line: string): string[] => {
-  const result: string[] = [];
-  let current = "";
-  let inQuotes = false;
-
-  for (let i = 0; i < line.length; i++) {
-    const char = line[i];
-
-    if (char === "\"") {
-      if (inQuotes && line[i + 1] === "\"") {
-        current += "\"";
-        i++;
-      } else {
-        inQuotes = !inQuotes;
-      }
-    } else if (char === "," && !inQuotes) {
-      result.push(current);
-      current = "";
-    } else {
-      current += char;
-    }
-  }
-
-  result.push(current);
-  return result;
-};
-
-const parseCsv = (csvText: string): PuzzleRow[] => {
-  const lines = csvText
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
-
-  const puzzles: PuzzleRow[] = [];
-
-  for (const line of lines) {
-    const cells = parseCsvLine(line);
-
-    if (cells.length === 0) {
-      continue;
-    }
-
-    const dayValue = Number(cells[0]?.trim());
-
-    if (!Number.isInteger(dayValue) || dayValue < 1 || dayValue > 366) {
-      continue;
-    }
-
-    const levelOne = parseCategoryColumn(cells[1], 1);
-    const levelTwo = parseCategoryColumn(cells[2], 2);
-    const levelThree = parseCategoryColumn(cells[3], 3);
-    const levelFour = parseCategoryColumn(cells[4], 4);
-
-    if (!levelOne || !levelTwo || !levelThree || !levelFour) {
-      continue;
-    }
-
-    puzzles.push({
-      dayOfYear: dayValue,
-      categories: [levelOne, levelTwo, levelThree, levelFour],
-    });
-  }
-
-  return puzzles;
-};
-
-const buildPuzzleId = (data: Category[]): string =>
-  data
-    .map((category) =>
-      [category.level, category.category, ...category.items].join(":")
-    )
-    .join("|");
-
-type DailyPuzzle = {
-  categories: Category[];
-  puzzleId: string;
-  dayOfYear: number;
-};
-
-export const fetchDailyPuzzle = async (): Promise<DailyPuzzle> => {
-  const response = await fetch(CSV_URL, { cache: "no-store" });
+const requestPuzzleFromApi = async (): Promise<DailyPuzzle> => {
+  const response = await fetch("/api/puzzle", { cache: "no-store" });
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch puzzle data: ${response.status}`);
+    throw new Error(`Failed to fetch puzzle: ${response.status}`);
   }
 
-  const csvText = await response.text();
-  const puzzles = parseCsv(csvText);
+  const puzzle = (await response.json()) as DailyPuzzle;
 
-  if (puzzles.length === 0) {
-    throw new Error("No valid puzzle rows found in CSV");
+  return normalizePuzzle(puzzle);
+};
+
+export const fetchDailyPuzzle = async (
+  options: FetchDailyPuzzleOptions = {}
+): Promise<DailyPuzzle> => {
+  const { forceRefresh = false } = options;
+
+  if (pendingPuzzlePromise) {
+    return pendingPuzzlePromise;
   }
 
-  const todayDayOfYear = getAstanaDayOfYear();
-  const todaysPuzzle = puzzles.find((puzzle) => puzzle.dayOfYear === todayDayOfYear);
+  if (!forceRefresh && cachedPuzzle) {
+    return cachedPuzzle;
+  }
 
-  const selectedPuzzle = todaysPuzzle ?? puzzles[Math.floor(Math.random() * puzzles.length)];
+  const previousPuzzle = cachedPuzzle;
 
-  return {
-    categories: selectedPuzzle.categories,
-    puzzleId: buildPuzzleId(selectedPuzzle.categories),
-    dayOfYear: selectedPuzzle.dayOfYear,
-  };
+  if (forceRefresh) {
+    cachedPuzzle = null;
+  }
+
+  const fetchPromise = requestPuzzleFromApi()
+    .then((puzzle) => {
+      cachedPuzzle = puzzle;
+      return puzzle;
+    })
+    .catch((error) => {
+      if (forceRefresh) {
+        cachedPuzzle = previousPuzzle;
+      }
+      throw error;
+    })
+    .finally(() => {
+      pendingPuzzlePromise = null;
+    });
+
+  pendingPuzzlePromise = fetchPromise;
+
+  return fetchPromise;
 };

--- a/app/_examples.ts
+++ b/app/_examples.ts
@@ -1,37 +1,165 @@
 import { Category } from "./_types";
+import { getAstanaDayOfYear } from "./_time";
 
-export const categories: Category[] = [
-  {
-    category: "ПАРСЫТҮБІРЛІ СӨЗДЕР",
-    items: ["ОРАЗА", "АБЫРОЙ", "ПЕРІШТЕ", "КІНӘ"],
-    level: 1,
-  },
-  {
-    category: "ІЛЕ АЛАБЫНДАҒЫ ӨЗЕНДЕР",
-    items: ["КҮРТІ", "ҚАСҚЕЛЕҢ", "ШІЛІК", "ҚАС"],
-    level: 2,
-  },
-  {
-    category: "КӨНЕРГЕН АЙ АТАУЛАРЫ",
-    items: ["ДӘЛУ", "АҚЫРАП", "АМАЛ", "ӘСЕТ"],
-    level: 3,
-  },
-  {
-    category: "ӨЛШЕМ БІРЛІКТЕРІ",
-    items: ["ВОЛЬТ", "АМПЕР", "ОМ", "ВАТТ"],
-    level: 4,
+const CSV_URL =
+  "https://docs.google.com/spreadsheets/d/e/2PACX-1vQbFVnlcBrpSGHk8PSuGophCOSUl5N-U9HBI6G352dZPgGlZGK1AdA0xduUeqPSfSW-8Om7C8GV8rcb/pub?gid=1108981138&single=true&output=csv";
+
+type PuzzleRow = {
+  dayOfYear: number;
+  categories: Category[];
+};
+
+const normalizeText = (value: string): string =>
+  value.replace(/\s+/g, " ").trim().toLocaleUpperCase("kk-KZ");
+
+const parseCategoryColumn = (
+  value: string | undefined,
+  level: 1 | 2 | 3 | 4
+): Category | null => {
+  if (!value) {
+    return null;
   }
-];
+
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  const openParenIndex = trimmed.indexOf("(");
+  const closeParenIndex = trimmed.lastIndexOf(")");
+
+  if (openParenIndex === -1 || closeParenIndex === -1 || closeParenIndex <= openParenIndex) {
+    return null;
+  }
+
+  const categoryName = trimmed.slice(0, openParenIndex).trim();
+  const itemsSection = trimmed.slice(openParenIndex + 1, closeParenIndex).trim();
+
+  if (!categoryName || !itemsSection) {
+    return null;
+  }
+
+  const rawItems = itemsSection
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+
+  if (rawItems.length < 4) {
+    return null;
+  }
+
+  const normalizedCategory = normalizeText(categoryName);
+  const items = rawItems.slice(0, 4).map((item) => normalizeText(item));
+
+  return {
+    category: normalizedCategory,
+    items,
+    level,
+  };
+};
+
+const parseCsvLine = (line: string): string[] => {
+  const result: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+
+    if (char === "\"") {
+      if (inQuotes && line[i + 1] === "\"") {
+        current += "\"";
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (char === "," && !inQuotes) {
+      result.push(current);
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+
+  result.push(current);
+  return result;
+};
+
+const parseCsv = (csvText: string): PuzzleRow[] => {
+  const lines = csvText
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  const puzzles: PuzzleRow[] = [];
+
+  for (const line of lines) {
+    const cells = parseCsvLine(line);
+
+    if (cells.length === 0) {
+      continue;
+    }
+
+    const dayValue = Number(cells[0]?.trim());
+
+    if (!Number.isInteger(dayValue) || dayValue < 1 || dayValue > 366) {
+      continue;
+    }
+
+    const levelOne = parseCategoryColumn(cells[1], 1);
+    const levelTwo = parseCategoryColumn(cells[2], 2);
+    const levelThree = parseCategoryColumn(cells[3], 3);
+    const levelFour = parseCategoryColumn(cells[4], 4);
+
+    if (!levelOne || !levelTwo || !levelThree || !levelFour) {
+      continue;
+    }
+
+    puzzles.push({
+      dayOfYear: dayValue,
+      categories: [levelOne, levelTwo, levelThree, levelFour],
+    });
+  }
+
+  return puzzles;
+};
 
 const buildPuzzleId = (data: Category[]): string =>
   data
     .map((category) =>
-      [
-        category.level,
-        category.category,
-        ...category.items,
-      ].join(":")
+      [category.level, category.category, ...category.items].join(":")
     )
     .join("|");
 
-export const puzzleId = buildPuzzleId(categories);
+type DailyPuzzle = {
+  categories: Category[];
+  puzzleId: string;
+  dayOfYear: number;
+};
+
+export const fetchDailyPuzzle = async (): Promise<DailyPuzzle> => {
+  const response = await fetch(CSV_URL, { cache: "no-store" });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch puzzle data: ${response.status}`);
+  }
+
+  const csvText = await response.text();
+  const puzzles = parseCsv(csvText);
+
+  if (puzzles.length === 0) {
+    throw new Error("No valid puzzle rows found in CSV");
+  }
+
+  const todayDayOfYear = getAstanaDayOfYear();
+  const todaysPuzzle = puzzles.find((puzzle) => puzzle.dayOfYear === todayDayOfYear);
+
+  const selectedPuzzle = todaysPuzzle ?? puzzles[Math.floor(Math.random() * puzzles.length)];
+
+  return {
+    categories: selectedPuzzle.categories,
+    puzzleId: buildPuzzleId(selectedPuzzle.categories),
+    dayOfYear: selectedPuzzle.dayOfYear,
+  };
+};

--- a/app/_hooks/use-game-logic.ts
+++ b/app/_hooks/use-game-logic.ts
@@ -19,6 +19,10 @@ type StoredGameResult = {
 const STORAGE_KEY = "storedGameResult";
 const DEFAULT_MISTAKES_REMAINING = 4;
 
+type LoadPuzzleOptions = {
+  forceRefresh?: boolean;
+};
+
 const createShuffledGameWords = (categoryList: Category[]): Word[] =>
   shuffleArray(
     categoryList
@@ -114,6 +118,8 @@ export default function useGameLogic() {
   const isMountedRef = useRef(true);
 
   useEffect(() => {
+    isMountedRef.current = true;
+
     return () => {
       isMountedRef.current = false;
     };
@@ -131,7 +137,7 @@ export default function useGameLogic() {
     guessHistoryRef.current = [];
   }, []);
 
-  const loadPuzzle = useCallback(async () => {
+  const loadPuzzle = useCallback(async (options: LoadPuzzleOptions = {}) => {
     if (!isMountedRef.current) {
       return;
     }
@@ -139,7 +145,7 @@ export default function useGameLogic() {
     setIsPuzzleLoading(true);
 
     try {
-      const puzzle = await fetchDailyPuzzle();
+      const puzzle = await fetchDailyPuzzle(options);
 
       if (!isMountedRef.current) {
         return;
@@ -232,7 +238,7 @@ export default function useGameLogic() {
       clearStoredGameResult();
       initializeNewGame([]);
       currentAstanaDateRef.current = getAstanaDate();
-      await loadPuzzle();
+      await loadPuzzle({ forceRefresh: true });
     };
 
     const scheduleMidnightReset = () => {

--- a/app/_puzzle-data.ts
+++ b/app/_puzzle-data.ts
@@ -1,0 +1,168 @@
+import { Category } from "./_types";
+import { getAstanaDayOfYear } from "./_time";
+
+const CSV_URL =
+  "https://docs.google.com/spreadsheets/d/e/2PACX-1vQbFVnlcBrpSGHk8PSuGophCOSUl5N-U9HBI6G352dZPgGlZGK1AdA0xduUeqPSfSW-8Om7C8GV8rcb/pub?gid=1108981138&single=true&output=csv";
+
+type PuzzleRow = {
+  dayOfYear: number;
+  categories: Category[];
+};
+
+export const normalizeText = (value: string): string =>
+  value.replace(/\s+/g, " ").trim().toLocaleUpperCase("kk-KZ");
+
+const parseCategoryColumn = (
+  value: string | undefined,
+  level: 1 | 2 | 3 | 4
+): Category | null => {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  const openParenIndex = trimmed.indexOf("(");
+  const closeParenIndex = trimmed.lastIndexOf(")");
+
+  if (openParenIndex === -1 || closeParenIndex === -1 || closeParenIndex <= openParenIndex) {
+    return null;
+  }
+
+  const categoryName = trimmed.slice(0, openParenIndex).trim();
+  const itemsSection = trimmed.slice(openParenIndex + 1, closeParenIndex).trim();
+
+  if (!categoryName || !itemsSection) {
+    return null;
+  }
+
+  const rawItems = itemsSection
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+
+  if (rawItems.length < 4) {
+    return null;
+  }
+
+  const normalizedCategory = normalizeText(categoryName);
+  const items = rawItems.slice(0, 4).map((item) => normalizeText(item));
+
+  return {
+    category: normalizedCategory,
+    items,
+    level,
+  };
+};
+
+const parseCsvLine = (line: string): string[] => {
+  const result: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+
+    if (char === "\"") {
+      if (inQuotes && line[i + 1] === "\"") {
+        current += "\"";
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (char === "," && !inQuotes) {
+      result.push(current);
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+
+  result.push(current);
+  return result;
+};
+
+export const parseCsv = (csvText: string): PuzzleRow[] => {
+  const lines = csvText
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  const puzzles: PuzzleRow[] = [];
+
+  for (const line of lines) {
+    const cells = parseCsvLine(line);
+
+    if (cells.length === 0) {
+      continue;
+    }
+
+    const dayValue = Number(cells[0]?.trim());
+
+    if (!Number.isInteger(dayValue) || dayValue < 1 || dayValue > 366) {
+      continue;
+    }
+
+    const levelOne = parseCategoryColumn(cells[1], 1);
+    const levelTwo = parseCategoryColumn(cells[2], 2);
+    const levelThree = parseCategoryColumn(cells[3], 3);
+    const levelFour = parseCategoryColumn(cells[4], 4);
+
+    if (!levelOne || !levelTwo || !levelThree || !levelFour) {
+      continue;
+    }
+
+    puzzles.push({
+      dayOfYear: dayValue,
+      categories: [levelOne, levelTwo, levelThree, levelFour],
+    });
+  }
+
+  return puzzles;
+};
+
+const buildPuzzleId = (data: Category[]): string =>
+  data
+    .map((category) =>
+      [category.level, category.category, ...category.items].join(":")
+    )
+    .join("|");
+
+export type DailyPuzzle = {
+  categories: Category[];
+  puzzleId: string;
+  dayOfYear: number;
+};
+
+const selectDailyPuzzle = (puzzles: PuzzleRow[]): PuzzleRow => {
+  if (puzzles.length === 0) {
+    throw new Error("No valid puzzle rows found in CSV");
+  }
+
+  const todayDayOfYear = getAstanaDayOfYear();
+  const todaysPuzzle = puzzles.find((puzzle) => puzzle.dayOfYear === todayDayOfYear);
+
+  return todaysPuzzle ?? puzzles[Math.floor(Math.random() * puzzles.length)];
+};
+
+export const fetchCsvPuzzle = async (): Promise<DailyPuzzle> => {
+  const response = await fetch(CSV_URL, { cache: "no-store" });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch puzzle data: ${response.status}`);
+  }
+
+  const csvText = await response.text();
+  const puzzles = parseCsv(csvText);
+  const selectedPuzzle = selectDailyPuzzle(puzzles);
+
+  return {
+    categories: selectedPuzzle.categories,
+    puzzleId: buildPuzzleId(selectedPuzzle.categories),
+    dayOfYear: selectedPuzzle.dayOfYear,
+  };
+};

--- a/app/_time.ts
+++ b/app/_time.ts
@@ -1,0 +1,63 @@
+export const ASTANA_TIME_ZONE = "Asia/Almaty";
+
+const ASTANA_DATE_FORMATTER = new Intl.DateTimeFormat("en-CA", {
+  timeZone: ASTANA_TIME_ZONE,
+});
+
+const ASTANA_DATE_TIME_FORMATTER = new Intl.DateTimeFormat("en-CA", {
+  timeZone: ASTANA_TIME_ZONE,
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hour12: false,
+});
+
+type DateTimeParts = {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+};
+
+const getAstanaDateTimeParts = (): DateTimeParts => {
+  const parts = ASTANA_DATE_TIME_FORMATTER.formatToParts(new Date());
+
+  const getPartValue = (type: Intl.DateTimeFormatPart["type"]) =>
+    Number(parts.find((part) => part.type === type)?.value ?? "0");
+
+  return {
+    year: getPartValue("year"),
+    month: getPartValue("month"),
+    day: getPartValue("day"),
+    hour: getPartValue("hour"),
+    minute: getPartValue("minute"),
+    second: getPartValue("second"),
+  };
+};
+
+export const getAstanaDate = () => ASTANA_DATE_FORMATTER.format(new Date());
+
+export const getMsUntilNextAstanaMidnight = () => {
+  const now = new Date();
+  const { year, month, day, hour, minute, second } = getAstanaDateTimeParts();
+
+  const astanaNowAsUtc = Date.UTC(year, month - 1, day, hour, minute, second);
+  const offset = astanaNowAsUtc - now.getTime();
+  const nextMidnightAsUtc = Date.UTC(year, month - 1, day + 1, 0, 0, 0);
+  const midnightUtc = nextMidnightAsUtc - offset;
+
+  return Math.max(midnightUtc - now.getTime(), 0);
+};
+
+export const getAstanaDayOfYear = () => {
+  const { year, month, day } = getAstanaDateTimeParts();
+  const startOfYearUtc = Date.UTC(year, 0, 0);
+  const currentUtc = Date.UTC(year, month - 1, day);
+
+  return Math.floor((currentUtc - startOfYearUtc) / (24 * 60 * 60 * 1000));
+};

--- a/app/api/puzzle/route.ts
+++ b/app/api/puzzle/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+
+import { fetchCsvPuzzle } from "@/app/_puzzle-data";
+
+export async function GET() {
+  try {
+    const puzzle = await fetchCsvPuzzle();
+    return NextResponse.json(puzzle);
+  } catch (error) {
+    console.error("Failed to load puzzle data", error);
+    return NextResponse.json(
+      { error: "Failed to load puzzle data" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- load the public Google Sheets CSV, validate rows, and pick the day's puzzle or a random fallback
- add shared Astana timezone helpers for date, midnight, and day-of-year calculations
- update the game logic hook to fetch puzzles dynamically, reset state at midnight, and persist progress only when a puzzle is available

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d06f94ac3483338e61173dc44484c7