### PR TITLE
Fix puzzle loading by proxying CSV through API route

### DIFF
--- a/app/_examples.ts
+++ b/app/_examples.ts
@@ -1,165 +1,20 @@
-import { Category } from "./_types";
-import { getAstanaDayOfYear } from "./_time";
-
-const CSV_URL =
-  "https://docs.google.com/spreadsheets/d/e/2PACX-1vQbFVnlcBrpSGHk8PSuGophCOSUl5N-U9HBI6G352dZPgGlZGK1AdA0xduUeqPSfSW-8Om7C8GV8rcb/pub?gid=1108981138&single=true&output=csv";
-
-type PuzzleRow = {
-  dayOfYear: number;
-  categories: Category[];
-};
-
-const normalizeText = (value: string): string =>
-  value.replace(/\s+/g, " ").trim().toLocaleUpperCase("kk-KZ");
-
-const parseCategoryColumn = (
-  value: string | undefined,
-  level: 1 | 2 | 3 | 4
-): Category | null => {
-  if (!value) {
-    return null;
-  }
-
-  const trimmed = value.trim();
-
-  if (!trimmed) {
-    return null;
-  }
-
-  const openParenIndex = trimmed.indexOf("(");
-  const closeParenIndex = trimmed.lastIndexOf(")");
-
-  if (openParenIndex === -1 || closeParenIndex === -1 || closeParenIndex <= openParenIndex) {
-    return null;
-  }
-
-  const categoryName = trimmed.slice(0, openParenIndex).trim();
-  const itemsSection = trimmed.slice(openParenIndex + 1, closeParenIndex).trim();
-
-  if (!categoryName || !itemsSection) {
-    return null;
-  }
-
-  const rawItems = itemsSection
-    .split(",")
-    .map((item) => item.trim())
-    .filter((item) => item.length > 0);
-
-  if (rawItems.length < 4) {
-    return null;
-  }
-
-  const normalizedCategory = normalizeText(categoryName);
-  const items = rawItems.slice(0, 4).map((item) => normalizeText(item));
-
-  return {
-    category: normalizedCategory,
-    items,
-    level,
-  };
-};
-
-const parseCsvLine = (line: string): string[] => {
-  const result: string[] = [];
-  let current = "";
-  let inQuotes = false;
-
-  for (let i = 0; i < line.length; i++) {
-    const char = line[i];
-
-    if (char === "\"") {
-      if (inQuotes && line[i + 1] === "\"") {
-        current += "\"";
-        i++;
-      } else {
-        inQuotes = !inQuotes;
-      }
-    } else if (char === "," && !inQuotes) {
-      result.push(current);
-      current = "";
-    } else {
-      current += char;
-    }
-  }
-
-  result.push(current);
-  return result;
-};
-
-const parseCsv = (csvText: string): PuzzleRow[] => {
-  const lines = csvText
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
-
-  const puzzles: PuzzleRow[] = [];
-
-  for (const line of lines) {
-    const cells = parseCsvLine(line);
-
-    if (cells.length === 0) {
-      continue;
-    }
-
-    const dayValue = Number(cells[0]?.trim());
-
-    if (!Number.isInteger(dayValue) || dayValue < 1 || dayValue > 366) {
-      continue;
-    }
-
-    const levelOne = parseCategoryColumn(cells[1], 1);
-    const levelTwo = parseCategoryColumn(cells[2], 2);
-    const levelThree = parseCategoryColumn(cells[3], 3);
-    const levelFour = parseCategoryColumn(cells[4], 4);
-
-    if (!levelOne || !levelTwo || !levelThree || !levelFour) {
-      continue;
-    }
-
-    puzzles.push({
-      dayOfYear: dayValue,
-      categories: [levelOne, levelTwo, levelThree, levelFour],
-    });
-  }
-
-  return puzzles;
-};
-
-const buildPuzzleId = (data: Category[]): string =>
-  data
-    .map((category) =>
-      [category.level, category.category, ...category.items].join(":")
-    )
-    .join("|");
-
-type DailyPuzzle = {
-  categories: Category[];
-  puzzleId: string;
-  dayOfYear: number;
-};
+import { DailyPuzzle, normalizeText } from "./_puzzle-data";
 
 export const fetchDailyPuzzle = async (): Promise<DailyPuzzle> => {
-  const response = await fetch(CSV_URL, { cache: "no-store" });
+  const response = await fetch("/api/puzzle", { cache: "no-store" });
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch puzzle data: ${response.status}`);
+    throw new Error(`Failed to fetch puzzle: ${response.status}`);
   }
 
-  const csvText = await response.text();
-  const puzzles = parseCsv(csvText);
-
-  if (puzzles.length === 0) {
-    throw new Error("No valid puzzle rows found in CSV");
-  }
-
-  const todayDayOfYear = getAstanaDayOfYear();
-  const todaysPuzzle = puzzles.find((puzzle) => puzzle.dayOfYear === todayDayOfYear);
-
-  const selectedPuzzle = todaysPuzzle ?? puzzles[Math.floor(Math.random() * puzzles.length)];
+  const puzzle = (await response.json()) as DailyPuzzle;
 
   return {
-    categories: selectedPuzzle.categories,
-    puzzleId: buildPuzzleId(selectedPuzzle.categories),
-    dayOfYear: selectedPuzzle.dayOfYear,
+    ...puzzle,
+    categories: puzzle.categories.map((category) => ({
+      ...category,
+      category: normalizeText(category.category),
+      items: category.items.map((item) => normalizeText(item)),
+    })),
   };
 };

--- a/app/_examples.ts
+++ b/app/_examples.ts
@@ -1,6 +1,22 @@
 import { DailyPuzzle, normalizeText } from "./_puzzle-data";
 
-export const fetchDailyPuzzle = async (): Promise<DailyPuzzle> => {
+type FetchDailyPuzzleOptions = {
+  forceRefresh?: boolean;
+};
+
+const normalizePuzzle = (puzzle: DailyPuzzle): DailyPuzzle => ({
+  ...puzzle,
+  categories: puzzle.categories.map((category) => ({
+    ...category,
+    category: normalizeText(category.category),
+    items: category.items.map((item) => normalizeText(item)),
+  })),
+});
+
+let cachedPuzzle: DailyPuzzle | null = null;
+let pendingPuzzlePromise: Promise<DailyPuzzle> | null = null;
+
+const requestPuzzleFromApi = async (): Promise<DailyPuzzle> => {
   const response = await fetch("/api/puzzle", { cache: "no-store" });
 
   if (!response.ok) {
@@ -9,12 +25,44 @@ export const fetchDailyPuzzle = async (): Promise<DailyPuzzle> => {
 
   const puzzle = (await response.json()) as DailyPuzzle;
 
-  return {
-    ...puzzle,
-    categories: puzzle.categories.map((category) => ({
-      ...category,
-      category: normalizeText(category.category),
-      items: category.items.map((item) => normalizeText(item)),
-    })),
-  };
+  return normalizePuzzle(puzzle);
+};
+
+export const fetchDailyPuzzle = async (
+  options: FetchDailyPuzzleOptions = {}
+): Promise<DailyPuzzle> => {
+  const { forceRefresh = false } = options;
+
+  if (pendingPuzzlePromise) {
+    return pendingPuzzlePromise;
+  }
+
+  if (!forceRefresh && cachedPuzzle) {
+    return cachedPuzzle;
+  }
+
+  const previousPuzzle = cachedPuzzle;
+
+  if (forceRefresh) {
+    cachedPuzzle = null;
+  }
+
+  const fetchPromise = requestPuzzleFromApi()
+    .then((puzzle) => {
+      cachedPuzzle = puzzle;
+      return puzzle;
+    })
+    .catch((error) => {
+      if (forceRefresh) {
+        cachedPuzzle = previousPuzzle;
+      }
+      throw error;
+    })
+    .finally(() => {
+      pendingPuzzlePromise = null;
+    });
+
+  pendingPuzzlePromise = fetchPromise;
+
+  return fetchPromise;
 };

--- a/app/_hooks/use-game-logic.ts
+++ b/app/_hooks/use-game-logic.ts
@@ -114,6 +114,8 @@ export default function useGameLogic() {
   const isMountedRef = useRef(true);
 
   useEffect(() => {
+    isMountedRef.current = true;
+
     return () => {
       isMountedRef.current = false;
     };

--- a/app/_hooks/use-game-logic.ts
+++ b/app/_hooks/use-game-logic.ts
@@ -19,6 +19,10 @@ type StoredGameResult = {
 const STORAGE_KEY = "storedGameResult";
 const DEFAULT_MISTAKES_REMAINING = 4;
 
+type LoadPuzzleOptions = {
+  forceRefresh?: boolean;
+};
+
 const createShuffledGameWords = (categoryList: Category[]): Word[] =>
   shuffleArray(
     categoryList
@@ -133,7 +137,7 @@ export default function useGameLogic() {
     guessHistoryRef.current = [];
   }, []);
 
-  const loadPuzzle = useCallback(async () => {
+  const loadPuzzle = useCallback(async (options: LoadPuzzleOptions = {}) => {
     if (!isMountedRef.current) {
       return;
     }
@@ -141,7 +145,7 @@ export default function useGameLogic() {
     setIsPuzzleLoading(true);
 
     try {
-      const puzzle = await fetchDailyPuzzle();
+      const puzzle = await fetchDailyPuzzle(options);
 
       if (!isMountedRef.current) {
         return;
@@ -234,7 +238,7 @@ export default function useGameLogic() {
       clearStoredGameResult();
       initializeNewGame([]);
       currentAstanaDateRef.current = getAstanaDate();
-      await loadPuzzle();
+      await loadPuzzle({ forceRefresh: true });
     };
 
     const scheduleMidnightReset = () => {

--- a/app/_puzzle-data.ts
+++ b/app/_puzzle-data.ts
@@ -1,0 +1,168 @@
+import { Category } from "./_types";
+import { getAstanaDayOfYear } from "./_time";
+
+const CSV_URL =
+  "https://docs.google.com/spreadsheets/d/e/2PACX-1vQbFVnlcBrpSGHk8PSuGophCOSUl5N-U9HBI6G352dZPgGlZGK1AdA0xduUeqPSfSW-8Om7C8GV8rcb/pub?gid=1108981138&single=true&output=csv";
+
+type PuzzleRow = {
+  dayOfYear: number;
+  categories: Category[];
+};
+
+export const normalizeText = (value: string): string =>
+  value.replace(/\s+/g, " ").trim().toLocaleUpperCase("kk-KZ");
+
+const parseCategoryColumn = (
+  value: string | undefined,
+  level: 1 | 2 | 3 | 4
+): Category | null => {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  const openParenIndex = trimmed.indexOf("(");
+  const closeParenIndex = trimmed.lastIndexOf(")");
+
+  if (openParenIndex === -1 || closeParenIndex === -1 || closeParenIndex <= openParenIndex) {
+    return null;
+  }
+
+  const categoryName = trimmed.slice(0, openParenIndex).trim();
+  const itemsSection = trimmed.slice(openParenIndex + 1, closeParenIndex).trim();
+
+  if (!categoryName || !itemsSection) {
+    return null;
+  }
+
+  const rawItems = itemsSection
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+
+  if (rawItems.length < 4) {
+    return null;
+  }
+
+  const normalizedCategory = normalizeText(categoryName);
+  const items = rawItems.slice(0, 4).map((item) => normalizeText(item));
+
+  return {
+    category: normalizedCategory,
+    items,
+    level,
+  };
+};
+
+const parseCsvLine = (line: string): string[] => {
+  const result: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+
+    if (char === "\"") {
+      if (inQuotes && line[i + 1] === "\"") {
+        current += "\"";
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (char === "," && !inQuotes) {
+      result.push(current);
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+
+  result.push(current);
+  return result;
+};
+
+export const parseCsv = (csvText: string): PuzzleRow[] => {
+  const lines = csvText
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  const puzzles: PuzzleRow[] = [];
+
+  for (const line of lines) {
+    const cells = parseCsvLine(line);
+
+    if (cells.length === 0) {
+      continue;
+    }
+
+    const dayValue = Number(cells[0]?.trim());
+
+    if (!Number.isInteger(dayValue) || dayValue < 1 || dayValue > 366) {
+      continue;
+    }
+
+    const levelOne = parseCategoryColumn(cells[1], 1);
+    const levelTwo = parseCategoryColumn(cells[2], 2);
+    const levelThree = parseCategoryColumn(cells[3], 3);
+    const levelFour = parseCategoryColumn(cells[4], 4);
+
+    if (!levelOne || !levelTwo || !levelThree || !levelFour) {
+      continue;
+    }
+
+    puzzles.push({
+      dayOfYear: dayValue,
+      categories: [levelOne, levelTwo, levelThree, levelFour],
+    });
+  }
+
+  return puzzles;
+};
+
+const buildPuzzleId = (data: Category[]): string =>
+  data
+    .map((category) =>
+      [category.level, category.category, ...category.items].join(":")
+    )
+    .join("|");
+
+export type DailyPuzzle = {
+  categories: Category[];
+  puzzleId: string;
+  dayOfYear: number;
+};
+
+const selectDailyPuzzle = (puzzles: PuzzleRow[]): PuzzleRow => {
+  if (puzzles.length === 0) {
+    throw new Error("No valid puzzle rows found in CSV");
+  }
+
+  const todayDayOfYear = getAstanaDayOfYear();
+  const todaysPuzzle = puzzles.find((puzzle) => puzzle.dayOfYear === todayDayOfYear);
+
+  return todaysPuzzle ?? puzzles[Math.floor(Math.random() * puzzles.length)];
+};
+
+export const fetchCsvPuzzle = async (): Promise<DailyPuzzle> => {
+  const response = await fetch(CSV_URL, { cache: "no-store" });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch puzzle data: ${response.status}`);
+  }
+
+  const csvText = await response.text();
+  const puzzles = parseCsv(csvText);
+  const selectedPuzzle = selectDailyPuzzle(puzzles);
+
+  return {
+    categories: selectedPuzzle.categories,
+    puzzleId: buildPuzzleId(selectedPuzzle.categories),
+    dayOfYear: selectedPuzzle.dayOfYear,
+  };
+};

--- a/app/api/puzzle/route.ts
+++ b/app/api/puzzle/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+
+import { fetchCsvPuzzle } from "@/app/_puzzle-data";
+
+export async function GET() {
+  try {
+    const puzzle = await fetchCsvPuzzle();
+    return NextResponse.json(puzzle);
+  } catch (error) {
+    console.error("Failed to load puzzle data", error);
+    return NextResponse.json(
+      { error: "Failed to load puzzle data" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared puzzle data helper that parses the Google Sheets CSV and normalizes text to all caps
- create an `/api/puzzle` route that fetches the CSV server-side and returns the parsed puzzle of the day
- update the client puzzle fetcher to call the API and normalize all category names and items before use

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0744416288333a97a9b65aeb36935