### PR TITLE
Add navigation shortcut to Wordle site from result dialogs

### DIFF
--- a/app/_components/modal/game-lost-modal.tsx
+++ b/app/_components/modal/game-lost-modal.tsx
@@ -45,6 +45,10 @@ ${window.location.href}`;
     props.onClose();
   };
 
+  const handleGoToSozdilge = () => {
+    window.open("https://wordle.kz/", "_blank", "noopener,noreferrer");
+  };
+
 
   return (
     <GameModal isOpen={props.isOpen} onClose={props.onClose}>
@@ -54,7 +58,13 @@ ${window.location.href}`;
         </h1>
         <hr className="mb-2 md:mb-4 w-full"></hr>
         <GuessHistory guessHistory={props.guessHistory} />
-        <ControlButton text="Бөлісу" onClick={handleShare} />
+        <div className="mt-6 flex items-center justify-center gap-4">
+          <ControlButton text="Бөлісу" onClick={handleShare} />
+          <ControlButton
+            text="Сөзділге көшу"
+            onClick={handleGoToSozdilge}
+          />
+        </div>
       </div>
     </GameModal>
   );

--- a/app/_components/modal/game-won-modal.tsx
+++ b/app/_components/modal/game-won-modal.tsx
@@ -46,6 +46,10 @@ ${window.location.href}`;
     props.onClose();
   };
 
+  const handleGoToSozdilge = () => {
+    window.open("https://wordle.kz/", "_blank", "noopener,noreferrer");
+  };
+
   return (
     <GameModal isOpen={props.isOpen} onClose={props.onClose}>
       <div className="flex flex-col items-center justify-center px-12">
@@ -55,7 +59,13 @@ ${window.location.href}`;
         <hr className="mb-2 md:mb-4 w-full"></hr>
         <h2 className="text-black mb-8">{"Бүгінгі ойын жеңіспен аяқталды"}</h2>
         <GuessHistory guessHistory={props.guessHistory} />
-        <ControlButton text="Бөлісу" onClick={handleShare} />
+        <div className="mt-6 flex items-center justify-center gap-4">
+          <ControlButton text="Бөлісу" onClick={handleShare} />
+          <ControlButton
+            text="Сөзділге көшу"
+            onClick={handleGoToSozdilge}
+          />
+        </div>
       </div>
     </GameModal>
   );


### PR DESCRIPTION
## Summary
- add a Wordle navigation button alongside the existing share control in the win and loss dialogs
- center the control row and add spacing so both buttons are evenly aligned

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1124daa008333ac480d7738d6053e