### PR TITLE
Fetch puzzles directly from CSV source

### DIFF
--- a/app/_examples.ts
+++ b/app/_examples.ts
@@ -1,4 +1,4 @@
-import { DailyPuzzle, normalizeText } from "./_puzzle-data";
+import { DailyPuzzle, fetchCsvPuzzle, normalizeText } from "./_puzzle-data";
 
 type FetchDailyPuzzleOptions = {
   forceRefresh?: boolean;
@@ -16,14 +16,8 @@ const normalizePuzzle = (puzzle: DailyPuzzle): DailyPuzzle => ({
 let cachedPuzzle: DailyPuzzle | null = null;
 let pendingPuzzlePromise: Promise<DailyPuzzle> | null = null;
 
-const requestPuzzleFromApi = async (): Promise<DailyPuzzle> => {
-  const response = await fetch("/api/puzzle", { cache: "no-store" });
-
-  if (!response.ok) {
-    throw new Error(`Failed to fetch puzzle: ${response.status}`);
-  }
-
-  const puzzle = (await response.json()) as DailyPuzzle;
+const requestPuzzleFromCsv = async (): Promise<DailyPuzzle> => {
+  const puzzle = await fetchCsvPuzzle();
 
   return normalizePuzzle(puzzle);
 };
@@ -47,7 +41,7 @@ export const fetchDailyPuzzle = async (
     cachedPuzzle = null;
   }
 
-  const fetchPromise = requestPuzzleFromApi()
+  const fetchPromise = requestPuzzleFromCsv()
     .then((puzzle) => {
       cachedPuzzle = puzzle;
       return puzzle;


### PR DESCRIPTION
## Summary
- fetch the daily puzzle directly from the Google Sheets CSV so static exports always pull fresh data
- retain the existing client-side caching/normalization flow when loading puzzles

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1a2c5aacc83338443fce5db69a69a